### PR TITLE
Update anvil notes with the standard -> wholenode queue rename

### DIFF
--- a/anvil.txt
+++ b/anvil.txt
@@ -13,7 +13,7 @@ Regular Nodes
 -------------
 
 128 cores (2 CPUs * 64 cores/CPU - no hyperthreading);
-256 GB (256000 MB). "shared" and "debug" are shared; "standard" and
+256 GB (256000 MB). "shared" and "debug" are shared; "wholenode" and
 "wide" are whole node.  You are charged 1 SU/core/hour.
 
 "Max Queued" includes running jobs.
@@ -21,7 +21,7 @@ Regular Nodes
 Partition | Nodes/Job | Cores/Job   | Duration | Max Running | Max Queued |
 ----------+-----------+-------------+----------+-------------+------------|
 debug     | 2 nodes   | 256 cores   | 2 hrs    | 1           | 2          |
-standard  | 16 nodes  | 2,048 cores | 96 hrs   | 64          | 128        |
+wholenode | 16 nodes  | 2,048 cores | 96 hrs   | 64          | 128        |
 wide      | 56 nodes  | 7,168 cores | 12 hrs   | 5           | 10         |
 shared    | 1 node    | 128 cores   | 96 hrs   | 6400 cores  | -          |
 


### PR DESCRIPTION
announced in https://www.rcac.purdue.edu/news/4444